### PR TITLE
Support Meteor 2.3

### DIFF
--- a/package.js
+++ b/package.js
@@ -2,13 +2,13 @@
 
 Package.describe({
   summary: "Support anonymous logins",
-  version: "0.3.1",
+  version: "0.3.2",
   name: "brettle:accounts-anonymous",
   git: "https://github.com/brettle/meteor-accounts-anonymous.git"
 });
 
 Package.onUse(function(api) {
-  api.versionsFrom('1.0.4');
+  api.versionsFrom(['1.0.4', '2.3']);
   api.use(['accounts-base'], 'client');
   api.use(['accounts-base', 'callback-hook'], 'server');
   api.use('underscore', 'server');
@@ -20,7 +20,7 @@ Package.onUse(function(api) {
 });
 
 Package.onTest(function(api) {
-  api.versionsFrom('1.0.4');
+  api.versionsFrom(['1.0.4', '2.3']);
   api.use(['brettle:accounts-anonymous@0.3.1', 'accounts-base', 'tinytest'],
     ['client', 'server']);
   api.use('brettle:accounts-multiple@0.3.1');


### PR DESCRIPTION
Fix the package.js to support Meteor 2.3 and the major version bump of accounts packages that happens there.
Merge this and publish packages after Meteor 2.3 is released or else it won't work.